### PR TITLE
Use dill

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pylint>=1.4.4
 pandas
 pystan
 Cython
+dill

--- a/stancache/stancache.py
+++ b/stancache/stancache.py
@@ -1,5 +1,6 @@
 import os
-import dill as pickle
+import pickle
+import dill
 import pystan
 import hashlib
 import base64
@@ -24,7 +25,7 @@ def _mkdir_if_not_exists(path):
 
 
 def _pickle_dumps_digest(item):
-    s = pickle.dumps(item)
+    s = dill.dumps(item)
     h = _digest(s)
     return h
 

--- a/stancache/stancache.py
+++ b/stancache/stancache.py
@@ -1,5 +1,5 @@
 import os
-import pickle
+import dill as pickle
 import pystan
 import hashlib
 import base64


### PR DESCRIPTION
Fixes error in pickling stan models, when a function is passed to `pystan.stan`. This is a common scenario, e.g. when using the `init` parameter.