### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ nose>=1.3.3
 pylint>=1.4.4
 pandas
 pystan
-Cython
+cython>=0.22
+numpy
 dill
 xxhash


### PR DESCRIPTION
Ran into this error during installation from git:

```Running pystan-2.14.0.0/setup.py -q bdist_egg --dist-dir /var/folders/ky/6sjy1ddn0ml94pyt1n1rbl000000gn/T/easy_install-tfz1yiya/pystan-2.14.0.0/egg-dist-tmp-jjpe_hy7
error: Setup script exited with Cython>=0.22 and NumPy are required.```